### PR TITLE
Set reading buffer size at the `Archive` level

### DIFF
--- a/Sources/ZIPFoundation/Archive+Reading.swift
+++ b/Sources/ZIPFoundation/Archive+Reading.swift
@@ -22,9 +22,10 @@ extension Archive {
     ///   - progress: A progress object that can be used to track or cancel the extract operation.
     /// - Returns: The checksum of the processed content or 0 if the `skipCRC32` flag was set to `true`.
     /// - Throws: An error if the destination file cannot be written or the entry contains malformed content.
-    public func extract(_ entry: Entry, to url: URL, bufferSize: Int = defaultReadChunkSize,
+    public func extract(_ entry: Entry, to url: URL, bufferSize: Int? = nil,
                         skipCRC32: Bool = false, allowUncontainedSymlinks: Bool = false,
                         progress: Progress? = nil) async throws -> CRC32 {
+        let bufferSize = bufferSize ?? readChunkSize
         guard bufferSize > 0 else {
             throw ArchiveError.invalidBufferSize
         }
@@ -83,8 +84,9 @@ extension Archive {
     ///   - consumer: A closure that consumes contents of `Entry` as `Data` chunks.
     /// - Returns: The checksum of the processed content or 0 if the `skipCRC32` flag was set to `true`..
     /// - Throws: An error if the destination file cannot be written or the entry contains malformed content.
-    public func extract(_ entry: Entry, bufferSize: Int = defaultReadChunkSize, skipCRC32: Bool = false,
+    public func extract(_ entry: Entry, bufferSize: Int? = nil, skipCRC32: Bool = false,
                         progress: Progress? = nil, consumer: Consumer) async throws -> CRC32 {
+        let bufferSize = bufferSize ?? readChunkSize
         guard bufferSize > 0 else {
             throw ArchiveError.invalidBufferSize
         }
@@ -129,9 +131,10 @@ extension Archive {
     public func extractRange(
         _ range: Range<UInt64>,
         of entry: Entry,
-        bufferSize: Int = defaultReadChunkSize,
+        bufferSize: Int? = nil,
         consumer: Consumer
     ) async throws {
+        let bufferSize = bufferSize ?? readChunkSize
         guard entry.type == .file else {
             throw ArchiveError.entryIsNotAFile
         }

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -133,6 +133,9 @@ public final class Archive: AsyncSequence {
     public let url: URL?
     /// Access mode for an archive file.
     public let accessMode: AccessMode
+    
+    let readChunkSize: Int
+    
     var dataSource: DataSource
     var endOfCentralDirectoryRecord: EndOfCentralDirectoryRecord
     var zip64EndOfCentralDirectory: ZIP64EndOfCentralDirectory?
@@ -172,22 +175,24 @@ public final class Archive: AsyncSequence {
     ///   - The file URL _must_ point to an existing file for `AccessMode.read`.
     ///   - The file URL _must_ point to a non-existing file for `AccessMode.create`.
     ///   - The file URL _must_ point to an existing file for `AccessMode.update`.
-    public init(url: URL, accessMode mode: AccessMode, pathEncoding: String.Encoding? = nil) async throws {
+    public init(url: URL, accessMode mode: AccessMode, defaultReadChunkSize: Int = defaultReadChunkSize, pathEncoding: String.Encoding? = nil) async throws {
         self.url = url
         self.accessMode = mode
         self.pathEncoding = pathEncoding
         let config = try await Archive.makeBackingConfiguration(for: url, mode: mode)
         self.dataSource = config.dataSource
+        self.readChunkSize = defaultReadChunkSize
         self.endOfCentralDirectoryRecord = config.endOfCentralDirectoryRecord
         self.zip64EndOfCentralDirectory = config.zip64EndOfCentralDirectory
     }
 
-    public init(url: URL?, dataSource: DataSource, pathEncoding: String.Encoding? = nil) async throws {
+    public init(url: URL?, dataSource: DataSource, defaultReadChunkSize: Int = defaultReadChunkSize, pathEncoding: String.Encoding? = nil) async throws {
         self.url = url
         self.accessMode = .read
         self.pathEncoding = pathEncoding
         let config = try await Archive.makeBackingConfiguration(for: dataSource)
         self.dataSource = config.dataSource
+        self.readChunkSize = defaultReadChunkSize
         self.endOfCentralDirectoryRecord = config.endOfCentralDirectoryRecord
         self.zip64EndOfCentralDirectory = config.zip64EndOfCentralDirectory
     }
@@ -219,6 +224,7 @@ public final class Archive: AsyncSequence {
         self.pathEncoding = pathEncoding
         let config = try await Archive.makeBackingConfiguration(for: data, mode: mode)
         self.dataSource = config.dataSource
+        self.readChunkSize = defaultReadChunkSize
         self.memoryFile = config.memoryFile
         self.endOfCentralDirectoryRecord = config.endOfCentralDirectoryRecord
         self.zip64EndOfCentralDirectory = config.zip64EndOfCentralDirectory


### PR DESCRIPTION
Allows to customize the default reading buffer size for all reading operation on a single `Archive` object.

This is a better approach because the optimal buffer size depends on the `DataSource` (e.g. HTTP vs file system).