### PR TITLE
Make `Archive` thread-safe

### DIFF
--- a/Sources/ZIPFoundation/Archive+BackingConfiguration.swift
+++ b/Sources/ZIPFoundation/Archive+BackingConfiguration.swift
@@ -32,7 +32,7 @@ extension Archive {
         let dataSource: DataSource
         switch mode {
         case .read:
-            dataSource = try await FileDataSource(url: url, mode: .read)
+            dataSource = try await FileDataSource(url: url, isWritable: false)
         case .create:
             let endOfCentralDirectoryRecord = EndOfCentralDirectoryRecord(
                 numberOfDisk: 0, numberOfDiskStart: 0,
@@ -46,7 +46,7 @@ extension Archive {
             try endOfCentralDirectoryRecord.data.write(to: url, options: .withoutOverwriting)
             fallthrough
         case .update:
-            dataSource = try await FileDataSource(url: url, mode: .write)
+            dataSource = try await FileDataSource(url: url, isWritable: true)
         }
         
         return try await makeBackingConfiguration(for: dataSource)
@@ -56,7 +56,6 @@ extension Archive {
         guard let (eocdRecord, zip64EOCD) = try await Archive.scanForEndOfCentralDirectoryRecord(in: dataSource) else {
             throw ArchiveError.missingEndOfCentralDirectoryRecord
         }
-        try await dataSource.seek(to: 0)
         
         return BackingConfiguration(
             dataSource: dataSource,

--- a/Sources/ZIPFoundation/Archive+Helpers.swift
+++ b/Sources/ZIPFoundation/Archive+Helpers.swift
@@ -14,39 +14,67 @@ extension Archive {
 
     // MARK: - Reading
 
-    func readUncompressed(entry: Entry, bufferSize: Int, skipCRC32: Bool,
-                          progress: Progress? = nil, with consumer: Consumer) async throws -> CRC32 {
+    func readUncompressed(
+        transaction: DataSourceTransaction,
+        entry: Entry,
+        bufferSize: Int,
+        skipCRC32: Bool,
+        progress: Progress? = nil,
+        with consumer: Consumer
+    ) async throws -> CRC32 {
         let size = entry.centralDirectoryStructure.effectiveUncompressedSize
         guard size <= .max else { throw ArchiveError.invalidEntrySize }
-        return try await Data.consumePart(of: Int64(size), chunkSize: bufferSize, skipCRC32: skipCRC32,
-                                    provider: { (_, chunkSize) -> Data in
-                                        return try await self.dataSource.read(length: chunkSize)
-                                    }, consumer: { (data) in
-                                        if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
-                                        try await consumer(data)
-                                        progress?.completedUnitCount += Int64(data.count)
-                                    })
+        return try await Data.consumePart(
+            of: Int64(size),
+            chunkSize: bufferSize,
+            skipCRC32: skipCRC32,
+            provider: { (_, chunkSize) -> Data in
+                return try await transaction.read(length: chunkSize)
+            },
+            consumer: { (data) in
+                if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
+                try await consumer(data)
+                progress?.completedUnitCount += Int64(data.count)
+            }
+        )
     }
 
-    func readCompressed(entry: Entry, bufferSize: Int, skipCRC32: Bool,
-                        progress: Progress? = nil, with consumer: Consumer) async throws -> CRC32 {
+    func readCompressed(
+        transaction: DataSourceTransaction,
+        entry: Entry,
+        bufferSize: Int,
+        skipCRC32: Bool,
+        progress: Progress? = nil,
+        with consumer: Consumer
+    ) async throws -> CRC32 {
         let size = entry.centralDirectoryStructure.effectiveCompressedSize
         guard size <= .max else { throw ArchiveError.invalidEntrySize }
-        return try await Data.decompress(size: Int64(size), bufferSize: bufferSize, skipCRC32: skipCRC32,
-                                   provider: { (_, chunkSize) -> Data in
-                                    return try await self.dataSource.read(length: chunkSize)
-                                   }, consumer: { (data) in
-                                    if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
-                                    try await consumer(data)
-                                    progress?.completedUnitCount += Int64(data.count)
-                                   })
+        return try await Data.decompress(
+            size: Int64(size),
+            bufferSize: bufferSize,
+            skipCRC32: skipCRC32,
+            provider: { (_, chunkSize) -> Data in
+                return try await transaction.read(length: chunkSize)
+            },
+            consumer: { (data) in
+                if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
+                try await consumer(data)
+                progress?.completedUnitCount += Int64(data.count)
+            }
+        )
     }
 
     // MARK: - Writing
 
-    func writeEntry(uncompressedSize: Int64, type: Entry.EntryType,
-                    compressionMethod: CompressionMethod, bufferSize: Int, progress: Progress? = nil,
-                    provider: Provider) async throws -> (sizeWritten: Int64, crc32: CRC32) {
+    func writeEntry(
+        transaction: WritableDataSourceTransaction,
+        uncompressedSize: Int64,
+        type: Entry.EntryType,
+        compressionMethod: CompressionMethod,
+        bufferSize: Int,
+        progress: Progress? = nil,
+        provider: Provider
+    ) async throws -> (sizeWritten: Int64, crc32: CRC32) {
         var checksum = CRC32(0)
         var sizeWritten = Int64(0)
         switch type {
@@ -54,12 +82,14 @@ extension Archive {
             switch compressionMethod {
             case .none:
                 (sizeWritten, checksum) = try await self.writeUncompressed(
+                    transaction: transaction,
                     size: uncompressedSize,
                     bufferSize: bufferSize,
                     progress: progress, provider: provider
                 )
             case .deflate:
                 (sizeWritten, checksum) = try await self.writeCompressed(
+                    transaction: transaction,
                     size: uncompressedSize,
                     bufferSize: bufferSize,
                     progress: progress, provider: provider
@@ -69,17 +99,25 @@ extension Archive {
             _ = try await provider(0, 0)
             if let progress = progress { progress.completedUnitCount = progress.totalUnitCount }
         case .symlink:
-            let (linkSizeWritten, linkChecksum) = try await self.writeSymbolicLink(size: Int(uncompressedSize),
-                                                                             provider: provider)
+            let (linkSizeWritten, linkChecksum) = try await self.writeSymbolicLink(
+                transaction: transaction,
+                size: Int(uncompressedSize),
+                provider: provider
+            )
             (sizeWritten, checksum) = (Int64(linkSizeWritten), linkChecksum)
             if let progress = progress { progress.completedUnitCount = progress.totalUnitCount }
         }
         return (sizeWritten, checksum)
     }
 
-    func writeLocalFileHeader(path: String, compressionMethod: CompressionMethod,
-                              size: (uncompressed: UInt64, compressed: UInt64), checksum: CRC32,
-                              modificationDateTime: (UInt16, UInt16)) async throws -> LocalFileHeader {
+    func writeLocalFileHeader(
+        transaction: WritableDataSourceTransaction,
+        path: String,
+        compressionMethod: CompressionMethod,
+        size: (uncompressed: UInt64, compressed: UInt64),
+        checksum: CRC32,
+        modificationDateTime: (UInt16, UInt16)
+    ) async throws -> LocalFileHeader {
         // We always set Bit 11 in generalPurposeBitFlag, which indicates an UTF-8 encoded path.
         guard let fileNameData = path.data(using: .utf8) else { throw ArchiveError.invalidEntryPath }
 
@@ -94,32 +132,40 @@ extension Archive {
             compressedSizeOfLFH = .max
             extraFieldLength = UInt16(20) // 2 + 2 + 8 + 8
             versionNeededToExtract = Version.v45.rawValue
-            zip64ExtendedInformation = Entry.ZIP64ExtendedInformation(dataSize: extraFieldLength - 4,
-                                                                      uncompressedSize: size.uncompressed,
-                                                                      compressedSize: size.compressed,
-                                                                      relativeOffsetOfLocalHeader: 0,
-                                                                      diskNumberStart: 0)
+            zip64ExtendedInformation = Entry.ZIP64ExtendedInformation(
+                dataSize: extraFieldLength - 4,
+                uncompressedSize: size.uncompressed,
+                compressedSize: size.compressed,
+                relativeOffsetOfLocalHeader: 0,
+                diskNumberStart: 0
+            )
         } else {
             uncompressedSizeOfLFH = UInt32(size.uncompressed)
             compressedSizeOfLFH = UInt32(size.compressed)
         }
 
-        let localFileHeader = LocalFileHeader(versionNeededToExtract: versionNeededToExtract,
-                                              generalPurposeBitFlag: UInt16(2048),
-                                              compressionMethod: compressionMethod.rawValue,
-                                              lastModFileTime: modificationDateTime.1,
-                                              lastModFileDate: modificationDateTime.0, crc32: checksum,
-                                              compressedSize: compressedSizeOfLFH,
-                                              uncompressedSize: uncompressedSizeOfLFH,
-                                              fileNameLength: UInt16(fileNameData.count),
-                                              extraFieldLength: extraFieldLength, fileNameData: fileNameData,
-                                              extraFieldData: zip64ExtendedInformation?.data ?? Data())
-        try await writableDataSource.write(localFileHeader.data)
+        let localFileHeader = LocalFileHeader(
+            versionNeededToExtract: versionNeededToExtract,
+            generalPurposeBitFlag: UInt16(2048),
+            compressionMethod: compressionMethod.rawValue,
+            lastModFileTime: modificationDateTime.1,
+            lastModFileDate: modificationDateTime.0, crc32: checksum,
+            compressedSize: compressedSizeOfLFH,
+            uncompressedSize: uncompressedSizeOfLFH,
+            fileNameLength: UInt16(fileNameData.count),
+            extraFieldLength: extraFieldLength, fileNameData: fileNameData,
+            extraFieldData: zip64ExtendedInformation?.data ?? Data()
+        )
+        try await transaction.write(localFileHeader.data)
         return localFileHeader
     }
 
-    func writeCentralDirectoryStructure(localFileHeader: LocalFileHeader, relativeOffset: UInt64,
-                                        externalFileAttributes: UInt32) async throws -> CentralDirectoryStructure {
+    func writeCentralDirectoryStructure(
+        transaction: WritableDataSourceTransaction,
+        localFileHeader: LocalFileHeader,
+        relativeOffset: UInt64,
+        externalFileAttributes: UInt32
+    ) async throws -> CentralDirectoryStructure {
         var extraUncompressedSize: UInt64?
         var extraCompressedSize: UInt64?
         var extraOffset: UInt64?
@@ -143,26 +189,32 @@ extension Archive {
             .reduce(UInt16(0), { $0 + UInt16(MemoryLayout.size(ofValue: $1)) })
         if extraFieldLength > 0 {
             // Size of extra fields, shouldn't include the leading 4 bytes
-            zip64ExtendedInformation = Entry.ZIP64ExtendedInformation(dataSize: extraFieldLength,
-                                                                      uncompressedSize: extraUncompressedSize ?? 0,
-                                                                      compressedSize: extraCompressedSize ?? 0,
-                                                                      relativeOffsetOfLocalHeader: extraOffset ?? 0,
-                                                                      diskNumberStart: 0)
+            zip64ExtendedInformation = Entry.ZIP64ExtendedInformation(
+                dataSize: extraFieldLength,
+                uncompressedSize: extraUncompressedSize ?? 0,
+                compressedSize: extraCompressedSize ?? 0,
+                relativeOffsetOfLocalHeader: extraOffset ?? 0,
+                diskNumberStart: 0
+            )
             extraFieldLength += Entry.ZIP64ExtendedInformation.headerSize
         }
-        let centralDirectory = CentralDirectoryStructure(localFileHeader: localFileHeader,
-                                                         fileAttributes: externalFileAttributes,
-                                                         relativeOffset: relativeOffsetOfCD,
-                                                         extraField: (extraFieldLength,
-                                                                      zip64ExtendedInformation?.data ?? Data()))
-        try await writableDataSource.write(centralDirectory.data)
+        let centralDirectory = CentralDirectoryStructure(
+            localFileHeader: localFileHeader,
+            fileAttributes: externalFileAttributes,
+            relativeOffset: relativeOffsetOfCD,
+            extraField: (extraFieldLength, zip64ExtendedInformation?.data ?? Data())
+        )
+        try await transaction.write(centralDirectory.data)
         return centralDirectory
     }
 
-    func writeEndOfCentralDirectory(centralDirectoryStructure: CentralDirectoryStructure,
-                                    startOfCentralDirectory: UInt64,
-                                    startOfEndOfCentralDirectory: UInt64,
-                                    operation: ModifyOperation) async throws -> EndOfCentralDirectoryStructure {
+    func writeEndOfCentralDirectory(
+        transaction: WritableDataSourceTransaction,
+        centralDirectoryStructure: CentralDirectoryStructure,
+        startOfCentralDirectory: UInt64,
+        startOfEndOfCentralDirectory: UInt64,
+        operation: ModifyOperation
+    ) async throws -> EndOfCentralDirectoryStructure {
         var record = self.endOfCentralDirectoryRecord
         let sizeOfCD = self.sizeOfCentralDirectory
         let numberOfTotalEntries = self.totalNumberOfEntriesInCentralDirectory
@@ -197,21 +249,32 @@ extension Archive {
         // ZIP64 End of Central Directory
         var zip64EOCD: ZIP64EndOfCentralDirectory?
         if numberOfTotalEntriesForEOCD == .max || offsetOfCDForEOCD == .max || sizeOfCDForEOCD == .max {
-            zip64EOCD = try await self.writeZIP64EOCD(totalNumberOfEntries: updatedNumberOfEntries,
-                                                sizeOfCentralDirectory: updatedSizeOfCD,
-                                                offsetOfCentralDirectory: startOfCentralDirectory,
-                                                offsetOfEndOfCentralDirectory: startOfEndOfCentralDirectory)
+            zip64EOCD = try await self.writeZIP64EOCD(
+                transaction: transaction,
+                totalNumberOfEntries: updatedNumberOfEntries,
+                sizeOfCentralDirectory: updatedSizeOfCD,
+                offsetOfCentralDirectory: startOfCentralDirectory,
+                offsetOfEndOfCentralDirectory: startOfEndOfCentralDirectory
+            )
         }
-        record = EndOfCentralDirectoryRecord(record: record, numberOfEntriesOnDisk: numberOfTotalEntriesForEOCD,
-                                             numberOfEntriesInCentralDirectory: numberOfTotalEntriesForEOCD,
-                                             updatedSizeOfCentralDirectory: sizeOfCDForEOCD,
-                                             startOfCentralDirectory: offsetOfCDForEOCD)
-        try await writableDataSource.write(record.data)
+        record = EndOfCentralDirectoryRecord(
+            record: record,
+            numberOfEntriesOnDisk: numberOfTotalEntriesForEOCD,
+            numberOfEntriesInCentralDirectory: numberOfTotalEntriesForEOCD,
+            updatedSizeOfCentralDirectory: sizeOfCDForEOCD,
+            startOfCentralDirectory: offsetOfCDForEOCD
+        )
+        try await transaction.write(record.data)
         return (record, zip64EOCD)
     }
 
-    func writeUncompressed(size: Int64, bufferSize: Int, progress: Progress? = nil,
-                           provider: Provider) async throws -> (sizeWritten: Int64, checksum: CRC32) {
+    func writeUncompressed(
+        transaction: WritableDataSourceTransaction,
+        size: Int64,
+        bufferSize: Int,
+        progress: Progress? = nil,
+        provider: Provider
+    ) async throws -> (sizeWritten: Int64, checksum: CRC32) {
         var position: Int64 = 0
         var sizeWritten: Int64 = 0
         var checksum = CRC32(0)
@@ -220,7 +283,7 @@ extension Archive {
             let readSize = (size - position) >= bufferSize ? bufferSize : Int(size - position)
             let entryChunk = try await provider(position, readSize)
             checksum = entryChunk.crc32(checksum: checksum)
-            try await writableDataSource.write(entryChunk)
+            try await transaction.write(entryChunk)
             sizeWritten += Int64(entryChunk.count)
             position += Int64(bufferSize)
             progress?.completedUnitCount = sizeWritten
@@ -228,61 +291,82 @@ extension Archive {
         return (sizeWritten, checksum)
     }
 
-    func writeCompressed(size: Int64, bufferSize: Int, progress: Progress? = nil,
-                         provider: Provider) async throws -> (sizeWritten: Int64, checksum: CRC32) {
+    func writeCompressed(
+        transaction: WritableDataSourceTransaction,
+        size: Int64,
+        bufferSize: Int,
+        progress: Progress? = nil,
+        provider: Provider
+    ) async throws -> (sizeWritten: Int64, checksum: CRC32) {
         var sizeWritten: Int64 = 0
         let consumer: Consumer = { data in
-            try await self.writableDataSource.write(data)
+            try await transaction.write(data)
             sizeWritten += Int64(data.count)
         }
-        let checksum = try await Data.compress(size: size, bufferSize: bufferSize,
-                                         provider: { (position, size) -> Data in
-                                            if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
-                                            let data = try await provider(position, size)
-                                            progress?.completedUnitCount += Int64(data.count)
-                                            return data
-                                         }, consumer: consumer)
+        let checksum = try await Data.compress(
+            size: size, bufferSize: bufferSize,
+            provider: { (position, size) -> Data in
+                if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
+                let data = try await provider(position, size)
+                progress?.completedUnitCount += Int64(data.count)
+                return data
+            },
+            consumer: consumer
+        )
         return(sizeWritten, checksum)
     }
 
-    func writeSymbolicLink(size: Int, provider: Provider) async throws -> (sizeWritten: Int, checksum: CRC32) {
+    func writeSymbolicLink(
+        transaction: WritableDataSourceTransaction,
+        size: Int,
+        provider: Provider
+    ) async throws -> (sizeWritten: Int, checksum: CRC32) {
         // The reported size of a symlink is the number of characters in the path it points to.
         let linkData = try await provider(0, size)
         let checksum = linkData.crc32(checksum: 0)
-        try await writableDataSource.write(linkData)
+        try await transaction.write(linkData)
         return (linkData.count, checksum)
     }
 
-    func writeZIP64EOCD(totalNumberOfEntries: UInt64,
-                        sizeOfCentralDirectory: UInt64,
-                        offsetOfCentralDirectory: UInt64,
-                        offsetOfEndOfCentralDirectory: UInt64) async throws -> ZIP64EndOfCentralDirectory {
+    func writeZIP64EOCD(
+        transaction: WritableDataSourceTransaction,
+        totalNumberOfEntries: UInt64,
+        sizeOfCentralDirectory: UInt64,
+        offsetOfCentralDirectory: UInt64,
+        offsetOfEndOfCentralDirectory: UInt64
+    ) async throws -> ZIP64EndOfCentralDirectory {
         var zip64EOCD: ZIP64EndOfCentralDirectory = self.zip64EndOfCentralDirectory ?? {
             // Shouldn't include the leading 12 bytes: (size - 12 = 44)
-            let record = ZIP64EndOfCentralDirectoryRecord(sizeOfZIP64EndOfCentralDirectoryRecord: UInt64(44),
-                                                          versionMadeBy: UInt16(789),
-                                                          versionNeededToExtract: Version.v45.rawValue,
-                                                          numberOfDisk: 0, numberOfDiskStart: 0,
-                                                          totalNumberOfEntriesOnDisk: 0,
-                                                          totalNumberOfEntriesInCentralDirectory: 0,
-                                                          sizeOfCentralDirectory: 0,
-                                                          offsetToStartOfCentralDirectory: 0,
-                                                          zip64ExtensibleDataSector: Data())
-            let locator = ZIP64EndOfCentralDirectoryLocator(numberOfDiskWithZIP64EOCDRecordStart: 0,
-                                                            relativeOffsetOfZIP64EOCDRecord: 0,
-                                                            totalNumberOfDisk: 1)
+            let record = ZIP64EndOfCentralDirectoryRecord(
+                sizeOfZIP64EndOfCentralDirectoryRecord: UInt64(44),
+                versionMadeBy: UInt16(789),
+                versionNeededToExtract: Version.v45.rawValue,
+                numberOfDisk: 0, numberOfDiskStart: 0,
+                totalNumberOfEntriesOnDisk: 0,
+                totalNumberOfEntriesInCentralDirectory: 0,
+                sizeOfCentralDirectory: 0,
+                offsetToStartOfCentralDirectory: 0,
+                zip64ExtensibleDataSector: Data()
+            )
+            let locator = ZIP64EndOfCentralDirectoryLocator(
+                numberOfDiskWithZIP64EOCDRecordStart: 0,
+                relativeOffsetOfZIP64EOCDRecord: 0,
+                totalNumberOfDisk: 1
+            )
             return ZIP64EndOfCentralDirectory(record: record, locator: locator)
         }()
 
-        let updatedRecord = ZIP64EndOfCentralDirectoryRecord(record: zip64EOCD.record,
-                                                             numberOfEntriesOnDisk: totalNumberOfEntries,
-                                                             numberOfEntriesInCD: totalNumberOfEntries,
-                                                             sizeOfCentralDirectory: sizeOfCentralDirectory,
-                                                             offsetToStartOfCD: offsetOfCentralDirectory)
+        let updatedRecord = ZIP64EndOfCentralDirectoryRecord(
+            record: zip64EOCD.record,
+            numberOfEntriesOnDisk: totalNumberOfEntries,
+            numberOfEntriesInCD: totalNumberOfEntries,
+            sizeOfCentralDirectory: sizeOfCentralDirectory,
+            offsetToStartOfCD: offsetOfCentralDirectory
+        )
         let updatedLocator = ZIP64EndOfCentralDirectoryLocator(locator: zip64EOCD.locator,
                                                                offsetOfZIP64EOCDRecord: offsetOfEndOfCentralDirectory)
         zip64EOCD = ZIP64EndOfCentralDirectory(record: updatedRecord, locator: updatedLocator)
-        try await writableDataSource.write(zip64EOCD.data)
+        try await transaction.write(zip64EOCD.data)
         return zip64EOCD
     }
 }

--- a/Sources/ZIPFoundation/Archive+Progress.swift
+++ b/Sources/ZIPFoundation/Archive+Progress.swift
@@ -29,7 +29,7 @@ extension Archive {
     ///
     /// - Parameter entry: The entry that will be read.
     /// - Returns: The number of the work units.
-    public func totalUnitCountForReading(_ entry: Entry) -> Int64 {
+    public nonisolated func totalUnitCountForReading(_ entry: Entry) -> Int64 {
         switch entry.type {
         case .file, .symlink:
             return Int64(entry.uncompressedSize)
@@ -38,7 +38,7 @@ extension Archive {
         }
     }
 
-    func makeProgressForReading(_ entry: Entry) -> Progress {
+    nonisolated func makeProgressForReading(_ entry: Entry) -> Progress {
         return Progress(totalUnitCount: self.totalUnitCountForReading(entry))
     }
 
@@ -46,7 +46,7 @@ extension Archive {
     /// adding the file at `url` to the receiver.
     /// - Parameter entry: The entry that will be removed.
     /// - Returns: The number of the work units.
-    public func totalUnitCountForAddingItem(at url: URL) -> Int64 {
+    public nonisolated func totalUnitCountForAddingItem(at url: URL) -> Int64 {
         var count = Int64(0)
         do {
             let type = try FileManager.typeForItem(at: url)
@@ -60,7 +60,7 @@ extension Archive {
         return count
     }
 
-    func makeProgressForAddingItem(at url: URL) -> Progress {
+    nonisolated func makeProgressForAddingItem(at url: URL) -> Progress {
         return Progress(totalUnitCount: self.totalUnitCountForAddingItem(at: url))
     }
 }

--- a/Sources/ZIPFoundation/Archive+Writing.swift
+++ b/Sources/ZIPFoundation/Archive+Writing.swift
@@ -118,55 +118,78 @@ extension Archive {
                          modificationDate: Date = Date(), permissions: UInt16? = nil,
                          compressionMethod: CompressionMethod = .none, bufferSize: Int = defaultWriteChunkSize,
                          progress: Progress? = nil, provider: Provider) async throws {
-        guard self.accessMode != .read, let dataSource = dataSource as? WritableDataSource else { throw ArchiveError.unwritableArchive }
-        // Directories and symlinks cannot be compressed
-        let compressionMethod = type == .file ? compressionMethod : .none
-        progress?.totalUnitCount = type == .directory ? defaultDirectoryUnitCount : uncompressedSize
-        let (eocdRecord, zip64EOCD) = (self.endOfCentralDirectoryRecord, self.zip64EndOfCentralDirectory)
-        guard self.offsetToStartOfCentralDirectory <= .max else { throw ArchiveError.invalidCentralDirectoryOffset }
-        var startOfCD = self.offsetToStartOfCentralDirectory
-        try await dataSource.seek(to: startOfCD)
-        let existingSize = self.sizeOfCentralDirectory
-        let existingData = try await dataSource.read(length: Int(existingSize))
-        try await dataSource.seek(to: startOfCD)
-        let fileHeaderStart = try await dataSource.position()
-        let modDateTime = modificationDate.fileModificationDateTime
+        guard
+            accessMode != .read,
+            dataSource.isWritable
+        else {
+            throw ArchiveError.unwritableArchive
+        }
         
-        do {
-            // Local File Header
-            var localFileHeader = try await self.writeLocalFileHeader(path: path, compressionMethod: compressionMethod,
-                                                                size: (UInt64(uncompressedSize), 0), checksum: 0,
-                                                                modificationDateTime: modDateTime)
-            // File Data
-            let (written, checksum) = try await self.writeEntry(uncompressedSize: uncompressedSize, type: type,
-                                                          compressionMethod: compressionMethod, bufferSize: bufferSize,
-                                                          progress: progress, provider: provider)
-            startOfCD = try await dataSource.position()
-            // Write the local file header a second time. Now with compressedSize (if applicable) and a valid checksum.
-            try await dataSource.seek(to: fileHeaderStart)
-            localFileHeader = try await self.writeLocalFileHeader(path: path, compressionMethod: compressionMethod,
-                                                            size: (UInt64(uncompressedSize), UInt64(written)),
-                                                            checksum: checksum, modificationDateTime: modDateTime)
-            // Central Directory
-            try await dataSource.seek(to: startOfCD)
-            try await dataSource.writeLargeChunk(existingData, size: existingSize, bufferSize: bufferSize)
-            let permissions = permissions ?? (type == .directory ? defaultDirectoryPermissions : defaultFilePermissions)
-            let externalAttributes = FileManager.externalFileAttributesForEntry(of: type, permissions: permissions)
-            let centralDir = try await self.writeCentralDirectoryStructure(localFileHeader: localFileHeader,
-                                                                     relativeOffset: UInt64(fileHeaderStart),
-                                                                     externalFileAttributes: externalAttributes)
-            // End of Central Directory Record (including ZIP64 End of Central Directory Record/Locator)
-            let startOfEOCD = try await dataSource.position()
-            let eocd = try await self.writeEndOfCentralDirectory(centralDirectoryStructure: centralDir,
-                                                           startOfCentralDirectory: UInt64(startOfCD),
-                                                           startOfEndOfCentralDirectory: startOfEOCD, operation: .add)
-            (self.endOfCentralDirectoryRecord, self.zip64EndOfCentralDirectory) = eocd
+        try await dataSource.write { transaction in
+            // Directories and symlinks cannot be compressed
+            let compressionMethod = type == .file ? compressionMethod : .none
+            progress?.totalUnitCount = type == .directory ? defaultDirectoryUnitCount : uncompressedSize
+            let (eocdRecord, zip64EOCD) = (self.endOfCentralDirectoryRecord, self.zip64EndOfCentralDirectory)
+            guard self.offsetToStartOfCentralDirectory <= .max else { throw ArchiveError.invalidCentralDirectoryOffset }
+            var startOfCD = self.offsetToStartOfCentralDirectory
+            try await transaction.seek(to: startOfCD)
+            let existingSize = self.sizeOfCentralDirectory
+            let existingData = try await transaction.read(length: Int(existingSize))
+            try await transaction.seek(to: startOfCD)
+            let fileHeaderStart = try await transaction.position()
+            let modDateTime = modificationDate.fileModificationDateTime
             
-            try await dataSource.flush()
-            
-        } catch ArchiveError.cancelledOperation {
-            try await rollback(UInt64(fileHeaderStart), (existingData, existingSize), bufferSize, eocdRecord, zip64EOCD)
-            throw ArchiveError.cancelledOperation
+            do {
+                // Local File Header
+                var localFileHeader = try await self.writeLocalFileHeader(
+                    transaction: transaction,
+                    path: path, compressionMethod: compressionMethod,
+                    size: (UInt64(uncompressedSize), 0), checksum: 0,
+                    modificationDateTime: modDateTime
+                )
+                // File Data
+                let (written, checksum) = try await self.writeEntry(
+                    transaction: transaction,
+                    uncompressedSize: uncompressedSize, type: type,
+                    compressionMethod: compressionMethod, bufferSize: bufferSize,
+                    progress: progress, provider: provider
+                )
+                startOfCD = try await transaction.position()
+                // Write the local file header a second time. Now with compressedSize (if applicable) and a valid checksum.
+                try await transaction.seek(to: fileHeaderStart)
+                localFileHeader = try await self.writeLocalFileHeader(
+                    transaction: transaction,
+                    path: path, compressionMethod: compressionMethod,
+                    size: (UInt64(uncompressedSize), UInt64(written)),
+                    checksum: checksum, modificationDateTime: modDateTime
+                )
+                // Central Directory
+                try await transaction.seek(to: startOfCD)
+                try await transaction.writeLargeChunk(existingData, size: existingSize, bufferSize: bufferSize)
+                let permissions = permissions ?? (type == .directory ? defaultDirectoryPermissions : defaultFilePermissions)
+                let externalAttributes = FileManager.externalFileAttributesForEntry(of: type, permissions: permissions)
+                let centralDir = try await self.writeCentralDirectoryStructure(
+                    transaction: transaction,
+                    localFileHeader: localFileHeader,
+                    relativeOffset: UInt64(fileHeaderStart),
+                    externalFileAttributes: externalAttributes
+                )
+                // End of Central Directory Record (including ZIP64 End of Central Directory Record/Locator)
+                let startOfEOCD = try await transaction.position()
+                let eocd = try await self.writeEndOfCentralDirectory(
+                    transaction: transaction,
+                    centralDirectoryStructure: centralDir,
+                    startOfCentralDirectory: UInt64(startOfCD),
+                    startOfEndOfCentralDirectory: startOfEOCD, operation: .add
+                )
+                (self.endOfCentralDirectoryRecord, self.zip64EndOfCentralDirectory) = eocd
+                
+                try await transaction.flush()
+                
+            } catch ArchiveError.cancelledOperation {
+                try await rollback(transaction, UInt64(fileHeaderStart), (existingData, existingSize), bufferSize, eocdRecord, zip64EOCD)
+                throw ArchiveError.cancelledOperation
+            }
         }
     }
 
@@ -178,54 +201,65 @@ extension Archive {
     ///   - progress: A progress object that can be used to track or cancel the remove operation.
     /// - Throws: An error if the `Entry` is malformed or the receiver is not writable.
     public func remove(_ entry: Entry, bufferSize: Int = defaultReadChunkSize, progress: Progress? = nil) async throws {
-        guard self.accessMode != .read, let dataSource = dataSource as? WritableDataSource else { throw ArchiveError.unwritableArchive }
-        let (tempArchive, tempDir) = try await self.makeTempArchive()
-        defer { tempDir.map { try? FileManager().removeItem(at: $0) } }
-        progress?.totalUnitCount = self.totalUnitCountForRemoving(entry)
-        var centralDirectoryData = Data()
-        var offset: UInt64 = 0
-        for try await currentEntry in self {
-            let cds = currentEntry.centralDirectoryStructure
-            if currentEntry != entry {
-                let entryStart = cds.effectiveRelativeOffsetOfLocalHeader
-                try await dataSource.seek(to: entryStart)
-                let provider: Provider = { (_, chunkSize) -> Data in
-                    try await dataSource.read(length: chunkSize)
-                }
-                let consumer: Consumer = {
-                    if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
-                    try await tempArchive.writableDataSource.write($0)
-                    progress?.completedUnitCount += Int64($0.count)
-                }
-                guard currentEntry.localSize <= .max else { throw ArchiveError.invalidLocalHeaderSize }
-                _ = try await Data.consumePart(of: Int64(currentEntry.localSize), chunkSize: bufferSize,
-                                         provider: provider, consumer: consumer)
-                let updatedCentralDirectory = updateOffsetInCentralDirectory(centralDirectoryStructure: cds,
-                                                                             updatedOffset: entryStart - offset)
-                centralDirectoryData.append(updatedCentralDirectory.data)
-            } else { offset = currentEntry.localSize }
+        guard
+            accessMode != .read,
+            dataSource.isWritable
+        else {
+            throw ArchiveError.unwritableArchive
         }
-        let startOfCentralDirectory = try await tempArchive.dataSource.position()
-        try await tempArchive.writableDataSource.write(centralDirectoryData)
-        let startOfEndOfCentralDirectory = try await tempArchive.dataSource.position()
-        tempArchive.endOfCentralDirectoryRecord = self.endOfCentralDirectoryRecord
-        tempArchive.zip64EndOfCentralDirectory = self.zip64EndOfCentralDirectory
-        let ecodStructure = try await tempArchive.writeEndOfCentralDirectory(
-            centralDirectoryStructure: entry.centralDirectoryStructure,
-            startOfCentralDirectory: startOfCentralDirectory,
-            startOfEndOfCentralDirectory: startOfEndOfCentralDirectory,
-            operation: .remove
-        )
-        (tempArchive.endOfCentralDirectoryRecord, tempArchive.zip64EndOfCentralDirectory) = ecodStructure
-        (self.endOfCentralDirectoryRecord, self.zip64EndOfCentralDirectory) = ecodStructure
-        try await tempArchive.writableDataSource.flush()
-        try await self.replaceCurrentArchive(with: tempArchive)
+        
+        try await dataSource.write { transaction in
+            let (tempArchive, tempDir) = try await self.makeTempArchive()
+            
+            try await tempArchive.dataSource.write { tempTransaction in
+                defer { tempDir.map { try? FileManager().removeItem(at: $0) } }
+                progress?.totalUnitCount = self.totalUnitCountForRemoving(entry)
+                var centralDirectoryData = Data()
+                var offset: UInt64 = 0
+                for try await currentEntry in self {
+                    let cds = currentEntry.centralDirectoryStructure
+                    if currentEntry != entry {
+                        let entryStart = cds.effectiveRelativeOffsetOfLocalHeader
+                        try await transaction.seek(to: entryStart)
+                        let provider: Provider = { (_, chunkSize) -> Data in
+                            try await transaction.read(length: chunkSize)
+                        }
+                        let consumer: Consumer = { data in
+                            if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
+                            try await tempTransaction.write(data)
+                            progress?.completedUnitCount += Int64(data.count)
+                        }
+                        guard currentEntry.localSize <= .max else { throw ArchiveError.invalidLocalHeaderSize }
+                        _ = try await Data.consumePart(of: Int64(currentEntry.localSize), chunkSize: bufferSize,
+                                                       provider: provider, consumer: consumer)
+                        let updatedCentralDirectory = updateOffsetInCentralDirectory(centralDirectoryStructure: cds,
+                                                                                     updatedOffset: entryStart - offset)
+                        centralDirectoryData.append(updatedCentralDirectory.data)
+                    } else { offset = currentEntry.localSize }
+                }
+                
+                let startOfCentralDirectory = try await tempTransaction.position()
+                try await tempTransaction.write(centralDirectoryData)
+                let startOfEndOfCentralDirectory = try await tempTransaction.position()
+                tempArchive.endOfCentralDirectoryRecord = self.endOfCentralDirectoryRecord
+                tempArchive.zip64EndOfCentralDirectory = self.zip64EndOfCentralDirectory
+                let ecodStructure = try await tempArchive.writeEndOfCentralDirectory(
+                    transaction: tempTransaction,
+                    centralDirectoryStructure: entry.centralDirectoryStructure,
+                    startOfCentralDirectory: startOfCentralDirectory,
+                    startOfEndOfCentralDirectory: startOfEndOfCentralDirectory,
+                    operation: .remove
+                )
+                (tempArchive.endOfCentralDirectoryRecord, tempArchive.zip64EndOfCentralDirectory) = ecodStructure
+                (self.endOfCentralDirectoryRecord, self.zip64EndOfCentralDirectory) = ecodStructure
+                try await tempTransaction.flush()
+                try await self.replaceCurrentArchive(with: tempArchive)
+            }
+        }
     }
 
     func replaceCurrentArchive(with archive: Archive) async throws {
         guard let url = self.url, let archiveURL = archive.url else { throw ArchiveError.unwritableArchive }
-        
-        try dataSource.close()
         
         let fileManager = FileManager()
 #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS) || os(watchOS)
@@ -239,7 +273,7 @@ extension Archive {
         _ = try fileManager.removeItem(at: url)
         _ = try fileManager.moveItem(at: archiveURL, to: url)
 #endif
-        self.dataSource = try await FileDataSource(url: url, mode: .write)
+        self.dataSource = try await FileDataSource(url: url, isWritable: true)
     }
 }
 
@@ -257,20 +291,28 @@ private extension Archive {
                                          relativeOffset: offsetInCD)
     }
 
-    func rollback(_ localFileHeaderStart: UInt64, _ existingCentralDirectory: (data: Data, size: UInt64),
-                  _ bufferSize: Int, _ endOfCentralDirRecord: EndOfCentralDirectoryRecord,
-                  _ zip64EndOfCentralDirectory: ZIP64EndOfCentralDirectory?) async throws {
-        try await writableDataSource.flush()
-        try await writableDataSource.truncate(to: localFileHeaderStart)
-        try await writableDataSource.seek(to: localFileHeaderStart)
-        try await writableDataSource.writeLargeChunk(existingCentralDirectory.data, size: existingCentralDirectory.size,
-                                     bufferSize: bufferSize)
-        try await writableDataSource.write(existingCentralDirectory.data)
+    func rollback(
+        _ transaction: WritableDataSourceTransaction,
+        _ localFileHeaderStart: UInt64,
+        _ existingCentralDirectory: (data: Data, size: UInt64),
+        _ bufferSize: Int,
+        _ endOfCentralDirRecord: EndOfCentralDirectoryRecord,
+        _ zip64EndOfCentralDirectory: ZIP64EndOfCentralDirectory?
+    ) async throws {
+        try await transaction.flush()
+        try await transaction.truncate(to: localFileHeaderStart)
+        try await transaction.seek(to: localFileHeaderStart)
+        try await transaction.writeLargeChunk(
+            existingCentralDirectory.data,
+            size: existingCentralDirectory.size,
+            bufferSize: bufferSize
+        )
+        try await transaction.write(existingCentralDirectory.data)
         if let zip64EOCD = zip64EndOfCentralDirectory {
-            try await writableDataSource.write(zip64EOCD.data)
+            try await transaction.write(zip64EOCD.data)
         }
-        try await writableDataSource.write(endOfCentralDirRecord.data)
-        try await writableDataSource.flush()
+        try await transaction.write(endOfCentralDirRecord.data)
+        try await transaction.flush()
     }
 
     func makeTempArchive() async throws -> (Archive, URL?) {

--- a/Sources/ZIPFoundation/Archive+ZIP64.swift
+++ b/Sources/ZIPFoundation/Archive+ZIP64.swift
@@ -143,8 +143,9 @@ extension Archive.ZIP64EndOfCentralDirectory {
 }
 
 /// Properties that represent the maximum value of each field
-var maxUInt32 = UInt32.max
-var maxUInt16 = UInt16.max
+// Unsafe mutability is used in the unit test suite.
+nonisolated(unsafe) var maxUInt32 = UInt32.max
+nonisolated(unsafe) var maxUInt16 = UInt16.max
 
 var maxCompressedSize: UInt32 { maxUInt32 }
 var maxUncompressedSize: UInt32 { maxUInt32 }

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -52,7 +52,7 @@ let centralDirectoryStructSignature = 0x02014b50
 ///     var archiveURL = URL(fileURLWithPath: "/path/file.zip")
 ///     var archive = Archive(url: archiveURL, accessMode: .update)
 ///     try archive?.addEntry("test.txt", relativeTo: baseURL, compressionMethod: .deflate)
-public final class Archive: AsyncSequence {
+public actor Archive: AsyncSequence {
     public typealias Element = Entry
     
 
@@ -100,7 +100,7 @@ public final class Archive: AsyncSequence {
     }
 
     /// The access mode for an `Archive`.
-    public enum AccessMode: UInt {
+    public enum AccessMode: UInt, Sendable {
         /// Indicates that a newly instantiated `Archive` should create its backing file.
         case create
         /// Indicates that a newly instantiated `Archive` should read from an existing backing file.
@@ -131,17 +131,30 @@ public final class Archive: AsyncSequence {
     }
 
     /// URL of an Archive's backing file.
-    public let url: URL?
+    public nonisolated let url: URL?
     /// Access mode for an archive file.
-    public let accessMode: AccessMode
+    public nonisolated let accessMode: AccessMode
     
-    let readChunkSize: Int
+    nonisolated let readChunkSize: Int
     
     var dataSource: DataSource
-    var endOfCentralDirectoryRecord: EndOfCentralDirectoryRecord
-    var zip64EndOfCentralDirectory: ZIP64EndOfCentralDirectory?
-    var pathEncoding: String.Encoding?
+    private(set) var endOfCentralDirectoryRecord: EndOfCentralDirectoryRecord
+    private(set) var zip64EndOfCentralDirectory: ZIP64EndOfCentralDirectory?
+    private var pathEncoding: String.Encoding?
     
+    var endOfCentralDirectory: EndOfCentralDirectoryStructure {
+        (endOfCentralDirectoryRecord, zip64EndOfCentralDirectory)
+    }
+    
+    func setEndOfCentralDirectory(_ structure: EndOfCentralDirectoryStructure) {
+        endOfCentralDirectoryRecord = structure.0
+        zip64EndOfCentralDirectory = structure.1
+    }
+    
+    func setZIP64EndOfCentralDirectory(_ directory: ZIP64EndOfCentralDirectory?) {
+        zip64EndOfCentralDirectory = directory
+    }
+
     var totalNumberOfEntriesInCentralDirectory: UInt64 {
         zip64EndOfCentralDirectory?.record.totalNumberOfEntriesInCentralDirectory
         ?? UInt64(endOfCentralDirectoryRecord.totalNumberOfEntriesInCentralDirectory)
@@ -193,53 +206,45 @@ public final class Archive: AsyncSequence {
         self.zip64EndOfCentralDirectory = config.zip64EndOfCentralDirectory
     }
 
-    public func makeAsyncIterator() -> Iterator {
-        Iterator(
-            dataSource: dataSource,
-            totalNumberOfEntriesInCD: totalNumberOfEntriesInCentralDirectory,
-            directoryIndex: offsetToStartOfCentralDirectory
-        )
+    public nonisolated func makeAsyncIterator() -> Iterator {
+        Iterator(archive: self)
     }
     
     public actor Iterator: AsyncIteratorProtocol {
-        private let dataSource: DataSource
-        private let totalNumberOfEntriesInCD: UInt64
-        private var directoryIndex: UInt64
+        
+        private struct Input {
+            let transaction: DataSourceTransaction
+            let totalNumberOfEntriesInCD: UInt64
+        }
+        
+        private let archive: Archive
+        private var directoryIndex: UInt64 = 0
         private var index = 0
         
-        fileprivate init(
-            dataSource: DataSource,
-            totalNumberOfEntriesInCD: UInt64,
-            directoryIndex: UInt64
-        ) {
-            self.dataSource = dataSource
-            self.totalNumberOfEntriesInCD = totalNumberOfEntriesInCD
-            self.directoryIndex = directoryIndex
+        fileprivate init(archive: Archive) {
+            self.archive = archive
         }
         
-        private var _openTask: Task<DataSourceTransaction, Error>?
+        private var _initializeTask: Task<DataSourceTransaction, Error>?
         
-        private func open() async throws -> DataSourceTransaction {
-            if _openTask == nil {
-                _openTask = Task { try await dataSource.openRead() }
-            }
-            return try await _openTask!.value
-        }
-        
-        deinit {
-            if let task = _openTask {
-                Task {
-                    try? await task.value.close()
+        private func initialize() async throws -> DataSourceTransaction {
+            if _initializeTask == nil {
+                _initializeTask = Task {
+                    directoryIndex = await archive.offsetToStartOfCentralDirectory
+                    return try await archive.dataSource.openRead()
                 }
             }
+            
+            return try await _initializeTask!.value
         }
         
         public func next() async throws -> Entry? {
-            guard index < totalNumberOfEntriesInCD else {
+            let totalNumberOfEntries = await archive.totalNumberOfEntriesInCentralDirectory
+            guard index < totalNumberOfEntries else {
                 return nil
             }
-            
-            let dataSource = try await open()
+
+            let dataSource = try await initialize()
 
             do {
                 guard let centralDirStruct: CentralDirectoryStructure = try await dataSource.readStruct(at: directoryIndex) else {
@@ -296,25 +301,24 @@ public final class Archive: AsyncSequence {
 
     static func scanForEndOfCentralDirectoryRecord(in dataSource: DataSource)
     async throws -> EndOfCentralDirectoryStructure? {
-        try await dataSource.read { transaction in
-            var eocdOffset: UInt64 = 0
-            var index = minEndOfCentralDirectoryOffset
-            let archiveLength = try await dataSource.length()
-            while eocdOffset == 0 && index <= archiveLength {
-                try await transaction.seek(to: archiveLength - index)
-                let potentialDirectoryEndTag = try await transaction.readInt()
-                if potentialDirectoryEndTag == UInt32(endOfCentralDirectoryStructSignature) {
-                    eocdOffset = UInt64(archiveLength - index)
-                    guard let eocd: EndOfCentralDirectoryRecord = try await transaction.readStruct(at: eocdOffset) else {
-                        return nil
-                    }
-                    let zip64EOCD = try await scanForZIP64EndOfCentralDirectory(in: dataSource, eocdOffset: eocdOffset)
-                    return (eocd, zip64EOCD)
+        let transaction = try await dataSource.openRead()
+        var eocdOffset: UInt64 = 0
+        var index = minEndOfCentralDirectoryOffset
+        let archiveLength = try await dataSource.length()
+        while eocdOffset == 0 && index <= archiveLength {
+            try await transaction.seek(to: archiveLength - index)
+            let potentialDirectoryEndTag = try await transaction.readInt()
+            if potentialDirectoryEndTag == UInt32(endOfCentralDirectoryStructSignature) {
+                eocdOffset = UInt64(archiveLength - index)
+                guard let eocd: EndOfCentralDirectoryRecord = try await transaction.readStruct(at: eocdOffset) else {
+                    return nil
                 }
-                index += 1
+                let zip64EOCD = try await scanForZIP64EndOfCentralDirectory(in: dataSource, eocdOffset: eocdOffset)
+                return (eocd, zip64EOCD)
             }
-            return nil
+            index += 1
         }
+        return nil
     }
 
     private static func scanForZIP64EndOfCentralDirectory(in dataSource: DataSource, eocdOffset: UInt64)
@@ -323,19 +327,18 @@ public final class Archive: AsyncSequence {
             return nil
         }
         let locatorOffset = eocdOffset - UInt64(ZIP64EndOfCentralDirectoryLocator.size)
-
+        
         guard UInt64(ZIP64EndOfCentralDirectoryRecord.size) < locatorOffset else {
             return nil
         }
         
-        return try await dataSource.read { transaction in
-            let recordOffset = locatorOffset - UInt64(ZIP64EndOfCentralDirectoryRecord.size)
-            guard let locator: ZIP64EndOfCentralDirectoryLocator = try await transaction.readStruct(at: locatorOffset),
-                  let record: ZIP64EndOfCentralDirectoryRecord = try await transaction.readStruct(at: recordOffset) else {
-                return nil
-            }
-            return ZIP64EndOfCentralDirectory(record: record, locator: locator)
+        let transaction = try await dataSource.openRead()
+        let recordOffset = locatorOffset - UInt64(ZIP64EndOfCentralDirectoryRecord.size)
+        guard let locator: ZIP64EndOfCentralDirectoryLocator = try await transaction.readStruct(at: locatorOffset),
+              let record: ZIP64EndOfCentralDirectoryRecord = try await transaction.readStruct(at: recordOffset) else {
+            return nil
         }
+        return ZIP64EndOfCentralDirectory(record: record, locator: locator)
     }
 }
 

--- a/Sources/ZIPFoundation/Data+Compression.swift
+++ b/Sources/ZIPFoundation/Data+Compression.swift
@@ -15,7 +15,7 @@ import zlib
 #endif
 
 /// The compression method of an `Entry` in a ZIP `Archive`.
-public enum CompressionMethod: UInt16 {
+public enum CompressionMethod: UInt16, Sendable {
     /// Indicates that an `Entry` has no compression applied to its contents.
     case none = 0
     /// Indicates that contents of an `Entry` have been compressed with a zlib compatible Deflate algorithm.
@@ -28,14 +28,14 @@ public typealias CRC32 = UInt32
 /// - Parameters:
 ///   - data: A chunk of `Data` to consume.
 /// - Throws: Can throw to indicate errors during data consumption.
-public typealias Consumer = (_ data: Data) async throws -> Void
+public typealias Consumer = @Sendable (_ data: Data) async throws -> Void
 /// A custom handler that receives a position and a size that can be used to provide data from an arbitrary source.
 /// - Parameters:
 ///   - position: The current read position.
 ///   - size: The size of the chunk to provide.
 /// - Returns: A chunk of `Data`.
 /// - Throws: Can throw to indicate errors in the data source.
-public typealias Provider = (_ position: Int64, _ size: Int) async throws -> Data
+public typealias Provider = @Sendable (_ position: Int64, _ size: Int) async throws -> Data
 
 extension Data {
     enum CompressionError: Error {

--- a/Sources/ZIPFoundation/Data+Serialization.swift
+++ b/Sources/ZIPFoundation/Data+Serialization.swift
@@ -16,6 +16,8 @@ public typealias FILEPointer = OpaquePointer
 public typealias FILEPointer = UnsafeMutablePointer<FILE>
 #endif
 
+extension FILEPointer: @unchecked @retroactive Sendable {}
+
 protocol DataSerializable {
     static var size: Int { get }
     init?(data: Data, additionalDataProvider: (Int) async throws -> Data) async
@@ -89,7 +91,7 @@ extension Data {
         #endif
     }
 
-    static func write(chunk: Data, to file: FILEPointer) throws -> Int {
+    @Sendable static func write(chunk: Data, to file: FILEPointer) throws -> Int {
         var sizeWritten: Int = 0
         chunk.withUnsafeBytes { (rawBufferPointer) in
             if let baseAddress = rawBufferPointer.baseAddress, rawBufferPointer.count > 0 {

--- a/Sources/ZIPFoundation/DataSource.swift
+++ b/Sources/ZIPFoundation/DataSource.swift
@@ -35,31 +35,10 @@ extension DataSource {
     public func openWrite() async throws -> WritableDataSourceTransaction {
         throw DataSourceError.notWritable
     }
-    
-    /// Opens a transaction to read data from the source and closes it
-    /// automatically after running `body`.
-    func read<T: Sendable>(_ body: (DataSourceTransaction) async throws -> T) async throws -> T {
-        let transaction = try await openRead()
-        let result = try await body(transaction)
-        try await transaction.close()
-        return result
-    }
-    
-    /// Opens a transaction to modify the source and closes it automatically
-    /// after running `body`.
-    func write<T: Sendable>(_ body: (WritableDataSourceTransaction) async throws -> T) async throws -> T {
-        let transaction = try await openWrite()
-        let result = try await body(transaction)
-        try await transaction.close()
-        return result
-    }
 }
 
 /// A ``DataSource`` abstract the access to the ZIP data.
 public protocol DataSourceTransaction: Sendable {
-    
-    /// Closes the transaction.
-    func close() async throws
 
     /// Gets the current offset position.
     func position() async throws -> UInt64

--- a/Sources/ZIPFoundation/Entry+ZIP64.swift
+++ b/Sources/ZIPFoundation/Entry+ZIP64.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 
-protocol ExtensibleDataField {
+protocol ExtensibleDataField: Sendable {
     var headerID: UInt16 { get }
     var dataSize: UInt16 { get }
 }

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -17,7 +17,7 @@ import CoreFoundation
 /// Entries are identified by their `path`.
 public struct Entry: Equatable, Sendable {
     /// The type of an `Entry` in a ZIP `Archive`.
-    public enum EntryType: Int {
+    public enum EntryType: Int, Sendable {
         /// Indicates a regular file.
         case file
         /// Indicates a directory.

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -15,7 +15,7 @@ import CoreFoundation
 ///
 /// You can retrieve instances of `Entry` from an `Archive` via subscripting or iteration.
 /// Entries are identified by their `path`.
-public struct Entry: Equatable {
+public struct Entry: Equatable, Sendable {
     /// The type of an `Entry` in a ZIP `Archive`.
     public enum EntryType: Int {
         /// Indicates a regular file.
@@ -62,7 +62,7 @@ public struct Entry: Equatable {
         var extraFields: [ExtensibleDataField]?
     }
 
-    struct DataDescriptor<T: BinaryInteger>: DataSerializable {
+    struct DataDescriptor<T: BinaryInteger & Sendable>: DataSerializable, Sendable {
         let data: Data
         let dataDescriptorSignature = UInt32(dataDescriptorStructSignature)
         let crc32: UInt32
@@ -77,7 +77,7 @@ public struct Entry: Equatable {
     typealias DefaultDataDescriptor = DataDescriptor<UInt32>
     typealias ZIP64DataDescriptor = DataDescriptor<UInt64>
 
-    struct CentralDirectoryStructure: DataSerializable {
+    struct CentralDirectoryStructure: DataSerializable, Sendable {
         let centralDirectorySignature = UInt32(centralDirectoryStructSignature)
         let versionMadeBy: UInt16
         let versionNeededToExtract: UInt16

--- a/Sources/ZIPFoundation/FileDataSource.swift
+++ b/Sources/ZIPFoundation/FileDataSource.swift
@@ -50,7 +50,7 @@ private enum FileAccessMode: String {
 
 private actor FileDataSourceTransaction: WritableDataSourceTransaction {
 
-    private var file: FILEPointer
+    private let file: FILEPointer
     
     init(url: URL, mode: FileAccessMode) async throws {
         self.file = try url.open(mode: mode)
@@ -61,9 +61,8 @@ private actor FileDataSourceTransaction: WritableDataSourceTransaction {
         try await seek(to: 0)
     }
     
-    func close() async throws {
+    deinit {
         fclose(file)
-        try checkNoError()
     }
 
     func position() async throws -> UInt64 {

--- a/Sources/ZIPFoundation/SharedMutableValue.swift
+++ b/Sources/ZIPFoundation/SharedMutableValue.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright 2025 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+
+actor SharedMutableValue<Value> {
+    private var value: Value
+    
+    init(_ value: Value) {
+        self.value = value
+    }
+    
+    func get() -> Value {
+        value
+    }
+    
+    func set(_ newValue: Value) {
+        value = newValue
+    }
+}
+
+extension SharedMutableValue where Value: Numeric {
+    
+    init() {
+        self.init(0)
+    }
+    
+    func increment(_ i: Value) {
+        value += i
+    }
+}

--- a/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests+ZIP64.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests+ZIP64.swift
@@ -15,37 +15,39 @@ extension ZIPFoundationTests {
 
     func testWriteEOCDWithTooLargeSizeOfCentralDirectory() async throws {
         let archive = await self.archive(for: #function, mode: .create)
-        archive.zip64EndOfCentralDirectory = makeMockZIP64EndOfCentralDirectory(sizeOfCentralDirectory: .max,
-                                                                                numberOfEntries: 0)
-        try await archive.dataSource.write { transaction in
-            await XCTAssertSwiftError(
-                try await archive.writeEndOfCentralDirectory(
-                    transaction: transaction,
-                    centralDirectoryStructure: makeMockCentralDirectory()!,
-                    startOfCentralDirectory: 0,
-                    startOfEndOfCentralDirectory: 0,
-                    operation: .add
-                ),
-                throws: Archive.ArchiveError.invalidCentralDirectorySize)
-        }
+        await archive.setZIP64EndOfCentralDirectory(makeMockZIP64EndOfCentralDirectory(
+            sizeOfCentralDirectory: .max,
+            numberOfEntries: 0
+        ))
+        let transaction = try await archive.dataSource.openWrite()
+        await XCTAssertSwiftError(
+            try await archive.writeEndOfCentralDirectory(
+                transaction: transaction,
+                centralDirectoryStructure: makeMockCentralDirectory()!,
+                startOfCentralDirectory: 0,
+                startOfEndOfCentralDirectory: 0,
+                operation: .add
+            ),
+            throws: Archive.ArchiveError.invalidCentralDirectorySize)
     }
 
     func testWriteEOCDWithTooLargeCentralDirectoryOffset() async throws {
         let archive = await self.archive(for: #function, mode: .create)
-        archive.zip64EndOfCentralDirectory = makeMockZIP64EndOfCentralDirectory(sizeOfCentralDirectory: 0,
-                                                                                numberOfEntries: .max)
-        try await archive.dataSource.write { transaction in
-            await XCTAssertSwiftError(
-                try await archive.writeEndOfCentralDirectory(
-                    transaction: transaction,
-                    centralDirectoryStructure: makeMockCentralDirectory()!,
-                    startOfCentralDirectory: 0,
-                    startOfEndOfCentralDirectory: 0,
-                    operation: .add
-                ),
-                throws: Archive.ArchiveError.invalidCentralDirectoryEntryCount
-            )
-        }
+        await archive.setZIP64EndOfCentralDirectory(makeMockZIP64EndOfCentralDirectory(
+            sizeOfCentralDirectory: 0,
+            numberOfEntries: .max
+        ))
+        let transaction = try await archive.dataSource.openWrite()
+        await XCTAssertSwiftError(
+            try await archive.writeEndOfCentralDirectory(
+                transaction: transaction,
+                centralDirectoryStructure: makeMockCentralDirectory()!,
+                startOfCentralDirectory: 0,
+                startOfEndOfCentralDirectory: 0,
+                operation: .add
+            ),
+            throws: Archive.ArchiveError.invalidCentralDirectoryEntryCount
+        )
     }
 
     // MARK: - Helper

--- a/Tests/ZIPFoundationTests/ZIPFoundationPerformanceTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationPerformanceTests.swift
@@ -125,7 +125,7 @@ extension ZIPFoundationTests {
 }
 
 extension XCTestCase {
-    func measureAsync(timeout: TimeInterval = 100, _ block: @escaping () async -> Void) async {
+    func measureAsync(timeout: TimeInterval = 100, _ block: @Sendable @escaping () async -> Void) async {
         let exp = expectation(description: "Finished")
         Task {
             await block()

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -21,7 +21,7 @@ class ZIPFoundationTests: XCTestCase {
         return Bundle(for: self)
     }
 
-    static var tempZipDirectoryURL: URL = {
+    static let tempZipDirectoryURL: URL = {
         let processInfo = ProcessInfo.processInfo
         var tempZipDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
         tempZipDirectory.appendPathComponent("ZipTempDirectory")

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests.swift
@@ -257,7 +257,7 @@ extension ZIPFoundationTests {
         // uses. To exercise the error code path, we temporarily limit the number of open files for
         // the test process to exercise the error code path here.
         await XCTAssertNoThrowAsync(try await self.runWithFileDescriptorLimit(0) {
-            await XCTAssertCocoaError(try await archive.remove(entryToRemove), throwsErrorWithCode: .fileWriteUnknown)
+            await XCTAssertPOSIXError(try await archive.remove(entryToRemove), throwsErrorWithCode: .EMFILE)
         })
         let readonlyArchive = await self.archive(for: #function, mode: .read)
         await XCTAssertSwiftError(try await readonlyArchive.remove(entryToRemove), throws: Archive.ArchiveError.unwritableArchive)

--- a/ZIPFoundation.xcodeproj/project.pbxproj
+++ b/ZIPFoundation.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		BACE20B826F7CE6C003BA312 /* Archive+BackingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACE20B726F7CE6C003BA312 /* Archive+BackingConfiguration.swift */; };
 		BACE20BA26F7D18A003BA312 /* Archive+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACE20B926F7D18A003BA312 /* Archive+Helpers.swift */; };
 		BACE20BD26F7D545003BA312 /* Entry+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACE20BC26F7D545003BA312 /* Entry+Serialization.swift */; };
+		CAD796BF2D5BE0AD0014099B /* SharedMutableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAD796BE2D5BE09C0014099B /* SharedMutableValue.swift */; };
 		CAF35E4D2D1187060042C460 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF35E4B2D1187040042C460 /* DataSource.swift */; };
 		CAF35E502D11A4290042C460 /* FileDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF35E4E2D11A4260042C460 /* FileDataSource.swift */; };
 		OBJ_33 /* ZIPFoundationDataSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* ZIPFoundationDataSerializationTests.swift */; };
@@ -88,6 +89,7 @@
 		BACE20B726F7CE6C003BA312 /* Archive+BackingConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+BackingConfiguration.swift"; sourceTree = "<group>"; };
 		BACE20B926F7D18A003BA312 /* Archive+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Helpers.swift"; sourceTree = "<group>"; };
 		BACE20BC26F7D545003BA312 /* Entry+Serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Entry+Serialization.swift"; sourceTree = "<group>"; };
+		CAD796BE2D5BE09C0014099B /* SharedMutableValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedMutableValue.swift; sourceTree = "<group>"; };
 		CAF35E4B2D1187040042C460 /* DataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
 		CAF35E4E2D11A4260042C460 /* FileDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDataSource.swift; sourceTree = "<group>"; };
 		OBJ_10 /* Archive+Writing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Writing.swift"; sourceTree = "<group>"; };
@@ -199,6 +201,7 @@
 		OBJ_8 /* ZIPFoundation */ = {
 			isa = PBXGroup;
 			children = (
+				CAD796BE2D5BE09C0014099B /* SharedMutableValue.swift */,
 				BA9AFCC72ABB642000A1268C /* Resources */,
 				OBJ_11 /* Archive.swift */,
 				BACE20B726F7CE6C003BA312 /* Archive+BackingConfiguration.swift */,
@@ -351,6 +354,7 @@
 				590A7DA626B0F8F800CBEFB4 /* Archive+ZIP64.swift in Sources */,
 				BA643D7A264811FB00018273 /* URL+ZIP.swift in Sources */,
 				BA58FB162951F49400892CE7 /* Date+ZIP.swift in Sources */,
+				CAD796BF2D5BE0AD0014099B /* SharedMutableValue.swift in Sources */,
 				OBJ_53 /* Entry.swift in Sources */,
 				OBJ_54 /* FileManager+ZIP.swift in Sources */,
 				BA643D7C2648131C00018273 /* Archive+Progress.swift in Sources */,


### PR DESCRIPTION
Make `Archive` thread-safe by transforming it into an async actor, and adding data source transactions to prevent race conditions.