### PR TITLE
On-the-fly local file headers parsing

### DIFF
--- a/Sources/ZIPFoundation/Archive+Progress.swift
+++ b/Sources/ZIPFoundation/Archive+Progress.swift
@@ -16,12 +16,12 @@ extension Archive {
     ///
     /// - Parameter entry: The entry that will be removed.
     /// - Returns: The number of the work units.
-    public func totalUnitCountForRemoving(_ entry: Entry) -> Int64 {
-        return Int64(self.offsetToStartOfCentralDirectory - entry.localSize)
+    func totalUnitCountForRemoving(_ entry: Entry, localFileHeader: LocalFileHeader) throws -> Int64 {
+        return try Int64(self.offsetToStartOfCentralDirectory - entry.localSize(with: localFileHeader))
     }
 
-    func makeProgressForRemoving(_ entry: Entry) -> Progress {
-        return Progress(totalUnitCount: self.totalUnitCountForRemoving(entry))
+    func makeProgressForRemoving(_ entry: Entry, localFileHeader: LocalFileHeader) throws -> Progress {
+        return Progress(totalUnitCount: try totalUnitCountForRemoving(entry, localFileHeader: localFileHeader))
     }
 
     /// The number of the work units that have to be performed when

--- a/Sources/ZIPFoundation/Archive.swift
+++ b/Sources/ZIPFoundation/Archive.swift
@@ -52,9 +52,7 @@ let centralDirectoryStructSignature = 0x02014b50
 ///     var archiveURL = URL(fileURLWithPath: "/path/file.zip")
 ///     var archive = Archive(url: archiveURL, accessMode: .update)
 ///     try archive?.addEntry("test.txt", relativeTo: baseURL, compressionMethod: .deflate)
-public actor Archive: AsyncSequence {
-    public typealias Element = Entry
-    
+public actor Archive {
 
     typealias LocalFileHeader = Entry.LocalFileHeader
     typealias DataDescriptor = Entry.DefaultDataDescriptor
@@ -208,62 +206,42 @@ public actor Archive: AsyncSequence {
         self.zip64EndOfCentralDirectory = config.zip64EndOfCentralDirectory
     }
 
-    public nonisolated func makeAsyncIterator() -> Iterator {
-        Iterator(archive: self)
+    private var entriesTask: Task<[Entry], Error>?
+    
+    /// Returns the list of entries in the archive.
+    public func entries() async throws -> [Entry] {
+        if entriesTask == nil {
+            entriesTask = Task { try await readEntries() }
+        }
+        
+        return try await entriesTask!.value
     }
     
-    public actor Iterator: AsyncIteratorProtocol {
-        
-        private struct Input {
-            let transaction: DataSourceTransaction
-            let totalNumberOfEntriesInCD: UInt64
+    private func readEntries() async throws -> [Entry] {
+        guard totalNumberOfEntriesInCentralDirectory > 0 else {
+            return []
         }
         
-        private let archive: Archive
-        private var directoryIndex: UInt64 = 0
-        private var index = 0
+        var entries: [Entry] = []
+        var directoryIndex = offsetToStartOfCentralDirectory
+        let transaction = try await dataSource.openRead()
         
-        fileprivate init(archive: Archive) {
-            self.archive = archive
-        }
-        
-        private var _initializeTask: Task<DataSourceTransaction, Error>?
-        
-        private func initialize() async throws -> DataSourceTransaction {
-            if _initializeTask == nil {
-                _initializeTask = Task {
-                    directoryIndex = await archive.offsetToStartOfCentralDirectory
-                    return try await archive.dataSource.openRead()
-                }
+        for _ in 0..<totalNumberOfEntriesInCentralDirectory {
+            guard let centralDirStruct: CentralDirectoryStructure = try await transaction.readStruct(at: directoryIndex) else {
+                continue
             }
             
-            return try await _initializeTask!.value
+            if let entry = Entry(centralDirectoryStructure: centralDirStruct) {
+                entries.append(entry)
+            }
+            
+            directoryIndex += UInt64(CentralDirectoryStructure.size)
+            directoryIndex += UInt64(centralDirStruct.fileNameLength)
+            directoryIndex += UInt64(centralDirStruct.extraFieldLength)
+            directoryIndex += UInt64(centralDirStruct.fileCommentLength)
         }
         
-        public func next() async throws -> Entry? {
-            let totalNumberOfEntries = await archive.totalNumberOfEntriesInCentralDirectory
-            guard index < totalNumberOfEntries else {
-                return nil
-            }
-
-            let dataSource = try await initialize()
-
-            do {
-                guard let centralDirStruct: CentralDirectoryStructure = try await dataSource.readStruct(at: directoryIndex) else {
-                    return nil
-                }
-                defer {
-                    directoryIndex += UInt64(CentralDirectoryStructure.size)
-                    directoryIndex += UInt64(centralDirStruct.fileNameLength)
-                    directoryIndex += UInt64(centralDirStruct.extraFieldLength)
-                    directoryIndex += UInt64(centralDirStruct.fileCommentLength)
-                    index += 1
-                }
-                return Entry(centralDirectoryStructure: centralDirStruct)
-            } catch {
-                return nil
-            }
-        }
+        return entries
     }
 
     /// Retrieve the ZIP `Entry` with the given `path` from the receiver.
@@ -275,40 +253,64 @@ public actor Archive: AsyncSequence {
     /// - Parameter path: A relative file path identifying the corresponding `Entry`.
     /// - Returns: An `Entry` with the given `path`. Otherwise, `nil`.
     public func get(_ path: String) async throws -> Entry? {
-        if let encoding = self.pathEncoding {
-            return try await self.first { $0.path(using: encoding) == path }
-        }
-        return try await self.first { $0.path == path }
-    }
-    
-    func localFileHeader(for entry: Entry) async throws -> LocalFileHeader {
-        let transaction = try await dataSource.openRead()
-        let centralDirStruct = entry.centralDirectoryStructure
-        let offset = UInt64(centralDirStruct.effectiveRelativeOffsetOfLocalHeader)
-        guard
-            var localFileHeader: LocalFileHeader = try await transaction.readStruct(at: offset)
-        else {
-            throw Archive.ArchiveError.localHeaderNotFound
-        }
-        
-        /// We only load the data descriptors if we are in writing mode, because
-        /// they might need to be written over. In read mode it is is
-        /// superfluous as the same infos are in the central directory structure.
-        if centralDirStruct.usesDataDescriptor && accessMode != .read {
-            let additionalSize = UInt64(localFileHeader.fileNameLength) + UInt64(localFileHeader.extraFieldLength)
-            let isCompressed = centralDirStruct.compressionMethod != CompressionMethod.none.rawValue
-            let dataSize = isCompressed
-            ? centralDirStruct.effectiveCompressedSize
-            : centralDirStruct.effectiveUncompressedSize
-            let descriptorPosition = offset + UInt64(LocalFileHeader.size) + additionalSize + dataSize
-            if centralDirStruct.isZIP64 {
-                localFileHeader.zip64DataDescriptor = try await transaction.readStruct(at: descriptorPosition)
+        let result = try await entries().first {
+            if let encoding = self.pathEncoding {
+                return $0.path(using: encoding) == path
             } else {
-                localFileHeader.dataDescriptor = try await transaction.readStruct(at: descriptorPosition)
+                return $0.path == path
             }
         }
+        return result
+    }
+    
+    /// Cache for local file headers.
+    private var localFileHeaders: [String: Task<LocalFileHeader, Error>] = [:]
+    
+    /// Retrieves the local file header for the given `entry`.
+    func localFileHeader(for entry: Entry) async throws -> LocalFileHeader {
+        if let task = localFileHeaders[entry.path] {
+            return try await task.value
+        }
         
-        return localFileHeader
+        let task = Task {
+            let transaction = try await dataSource.openRead()
+            let centralDirStruct = entry.centralDirectoryStructure
+            let offset = UInt64(centralDirStruct.effectiveRelativeOffsetOfLocalHeader)
+            guard
+                var localFileHeader: LocalFileHeader = try await transaction.readStruct(at: offset)
+            else {
+                throw Archive.ArchiveError.localHeaderNotFound
+            }
+            
+            /// We only load the data descriptors if we are in writing mode, because
+            /// they might need to be written over. In read mode it is is
+            /// superfluous as the same infos are in the central directory structure.
+            if centralDirStruct.usesDataDescriptor && accessMode != .read {
+                let additionalSize = UInt64(localFileHeader.fileNameLength) + UInt64(localFileHeader.extraFieldLength)
+                let isCompressed = centralDirStruct.compressionMethod != CompressionMethod.none.rawValue
+                let dataSize = isCompressed
+                ? centralDirStruct.effectiveCompressedSize
+                : centralDirStruct.effectiveUncompressedSize
+                let descriptorPosition = offset + UInt64(LocalFileHeader.size) + additionalSize + dataSize
+                if centralDirStruct.isZIP64 {
+                    localFileHeader.zip64DataDescriptor = try await transaction.readStruct(at: descriptorPosition)
+                } else {
+                    localFileHeader.dataDescriptor = try await transaction.readStruct(at: descriptorPosition)
+                }
+            }
+            
+            return localFileHeader
+        }
+        localFileHeaders[entry.path] = task
+        
+        return try await task.value
+    }
+    
+    /// Called when the archive was modified.
+    func didWrite() {
+        // Clears the caches.
+        entriesTask = nil
+        localFileHeaders = [:]
     }
 
     // MARK: - Helpers

--- a/Sources/ZIPFoundation/Entry.swift
+++ b/Sources/ZIPFoundation/Entry.swift
@@ -62,6 +62,14 @@ public struct Entry: Equatable, Sendable {
         var extraFields: [ExtensibleDataField]?
         var dataDescriptor: DefaultDataDescriptor?
         var zip64DataDescriptor: ZIP64DataDescriptor?
+        
+        var checksum: CRC32 {
+            if crc32 > 0 {
+                return crc32
+            } else {
+                return zip64DataDescriptor?.crc32 ?? dataDescriptor?.crc32 ?? 0
+            }
+        }
     }
 
     struct DataDescriptor<T: BinaryInteger & Sendable>: DataSerializable, Sendable {

--- a/Sources/ZIPFoundation/FileManager+ZIP.swift
+++ b/Sources/ZIPFoundation/FileManager+ZIP.swift
@@ -101,11 +101,11 @@ extension FileManager {
         let archive = try await Archive(url: sourceURL, accessMode: .read, pathEncoding: pathEncoding)
         var totalUnitCount = Int64(0)
         if let progress = progress {
-            totalUnitCount = try await archive.reduce(0, { $0 + archive.totalUnitCountForReading($1) })
+            totalUnitCount = try await archive.entries().reduce(0, { $0 + archive.totalUnitCountForReading($1) })
             progress.totalUnitCount = totalUnitCount
         }
 
-        for try await entry in archive {
+        for entry in try await archive.entries() {
             let path = pathEncoding == nil ? entry.path : entry.path(using: pathEncoding!)
             let entryURL = destinationURL.appendingPathComponent(path)
             guard entryURL.isContained(in: destinationURL) else {

--- a/Tests/ZIPFoundationTests/ZIPFoundationEntryTests+ZIP64.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationEntryTests+ZIP64.swift
@@ -108,7 +108,7 @@ extension ZIPFoundationTests {
                                               }) else {
             XCTFail("Failed to read local file header."); return
         }
-        guard let entry = Entry(centralDirectoryStructure: cds, localFileHeader: lfh) else {
+        guard let entry = Entry(centralDirectoryStructure: cds) else {
             XCTFail("Failed to create test entry."); return
         }
         XCTAssertNotNil(entry.zip64ExtendedInformation)

--- a/Tests/ZIPFoundationTests/ZIPFoundationEntryTests+ZIP64.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationEntryTests+ZIP64.swift
@@ -102,10 +102,10 @@ extension ZIPFoundationTests {
                                  0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                  0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x0a, 0x00,
                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
-        guard let lfh = await Entry.LocalFileHeader(data: Data(lfhBytes),
+        guard await Entry.LocalFileHeader(data: Data(lfhBytes),
                                               additionalDataProvider: { _ -> Data in
                                                 return Data()
-                                              }) else {
+                                              }) != nil else {
             XCTFail("Failed to read local file header."); return
         }
         guard let entry = Entry(centralDirectoryStructure: cds) else {

--- a/Tests/ZIPFoundationTests/ZIPFoundationEntryTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationEntryTests.swift
@@ -106,11 +106,11 @@ extension ZIPFoundationTests {
             XCTFail("Failed to read central directory structure.")
             return
         }
-        guard let local = lfh else {
+        guard lfh != nil else {
             XCTFail("Failed to read local file header.")
             return
         }
-        guard let entry = Entry(centralDirectoryStructure: central, localFileHeader: local) else {
+        guard let entry = Entry(centralDirectoryStructure: central) else {
             XCTFail("Failed to read entry.")
             return
         }
@@ -138,11 +138,11 @@ extension ZIPFoundationTests {
             XCTFail("Failed to read central directory structure.")
             return
         }
-        guard let local = lfh else {
+        guard lfh != nil else {
             XCTFail("Failed to read local file header.")
             return
         }
-        guard let entry = Entry(centralDirectoryStructure: central, localFileHeader: local) else {
+        guard let entry = Entry(centralDirectoryStructure: central) else {
             XCTFail("Failed to read entry.")
             return
         }
@@ -174,11 +174,11 @@ extension ZIPFoundationTests {
             XCTFail("Failed to read central directory structure.")
             return
         }
-        guard let local = lfh else {
+        guard lfh != nil else {
             XCTFail("Failed to read local file header.")
             return
         }
-        guard let entry = Entry(centralDirectoryStructure: central, localFileHeader: local) else {
+        guard let entry = Entry(centralDirectoryStructure: central) else {
             XCTFail("Failed to read entry.")
             return
         }

--- a/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
@@ -74,8 +74,11 @@ extension ZIPFoundationTests {
             try invalidLocalFHArchiveData.write(to: invalidLocalFHArchiveURL)
             let invalidLocalFHArchive = try await Archive(url: invalidLocalFHArchiveURL,
                                                     accessMode: .read)
-            for try await _ in invalidLocalFHArchive {
-                didFailToMakeIteratorAsExpected = false
+            for try await entry in invalidLocalFHArchive {
+                do {
+                    let localFile = try await invalidLocalFHArchive.localFileHeader(for: entry)
+                    didFailToMakeIteratorAsExpected = false
+                } catch {}
             }
         } catch {
             XCTFail("Unexpected error while testing iterator error conditions.")

--- a/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationErrorConditionTests.swift
@@ -58,7 +58,7 @@ extension ZIPFoundationTests {
         XCTAssert(result == true)
         let invalidCentralDirArchive = try await Archive(url: invalidCentralDirArchiveURL,
                                                    accessMode: .read)
-        for try await _ in invalidCentralDirArchive {
+        for _ in try await invalidCentralDirArchive.entries() {
             didFailToMakeIteratorAsExpected = false
         }
         XCTAssertTrue(didFailToMakeIteratorAsExpected)
@@ -74,9 +74,9 @@ extension ZIPFoundationTests {
             try invalidLocalFHArchiveData.write(to: invalidLocalFHArchiveURL)
             let invalidLocalFHArchive = try await Archive(url: invalidLocalFHArchiveURL,
                                                     accessMode: .read)
-            for try await entry in invalidLocalFHArchive {
+            for entry in try await invalidLocalFHArchive.entries() {
                 do {
-                    let localFile = try await invalidLocalFHArchive.localFileHeader(for: entry)
+                    _ = try await invalidLocalFHArchive.localFileHeader(for: entry)
                     didFailToMakeIteratorAsExpected = false
                 } catch {}
             }

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileAttributeTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileAttributeTests.swift
@@ -39,7 +39,7 @@ extension ZIPFoundationTests {
         else {
             XCTFail("Failed to read local file header."); return
         }
-        guard let entry = Entry(centralDirectoryStructure: cds, localFileHeader: lfh) else {
+        guard let entry = Entry(centralDirectoryStructure: cds) else {
             XCTFail("Failed to create test entry."); return
         }
         let attributes = FileManager.attributes(from: entry)

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileAttributeTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileAttributeTests.swift
@@ -34,8 +34,7 @@ extension ZIPFoundationTests {
                                  0x08, 0x00, 0xab, 0x85, 0x77, 0x47, 0x00, 0x00,
                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
-        guard let lfh = await Entry.LocalFileHeader(data: Data(lfhBytes),
-                                              additionalDataProvider: { _ -> Data in return Data() })
+        guard await Entry.LocalFileHeader(data: Data(lfhBytes), additionalDataProvider: { _ -> Data in return Data() }) != nil
         else {
             XCTFail("Failed to read local file header."); return
         }

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests+ZIP64.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests+ZIP64.swift
@@ -129,7 +129,7 @@ extension ZIPFoundationTests {
             throw ZIP64FileManagerTestsError.failedToUnzipItem
         }
         var itemsExist = false
-        for try await entry in archive {
+        for entry in try await archive.entries() {
             let directoryURL = destinationURL.appendingPathComponent(entry.path)
             itemsExist = fileManager.itemExists(at: directoryURL)
             if !itemsExist { break }

--- a/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationFileManagerTests.swift
@@ -95,7 +95,7 @@ extension ZIPFoundationTests {
             XCTFail("Failed to extract item."); return
         }
         var itemsExist = false
-        for try await entry in archive {
+        for entry in try await archive.entries() {
             let directoryURL = destinationURL.appendingPathComponent(entry.path)
             itemsExist = fileManager.itemExists(at: directoryURL)
             if itemsExist == false { break }
@@ -114,7 +114,7 @@ extension ZIPFoundationTests {
             XCTFail("Failed to extract item."); return
         }
         var itemsExist = false
-        for try await entry in archive {
+        for entry in try await archive.entries() {
             let directoryURL = destinationURL.appendingPathComponent(entry.path(using: encoding))
             itemsExist = fileManager.itemExists(at: directoryURL)
             if !itemsExist { break }

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -76,11 +76,12 @@ extension ZIPFoundationTests {
     }
 
     func testExtractCompressedDataDescriptorArchive() async throws {
-        let archive = await self.archive(for: #function, mode: .read)
+        let archive = await self.archive(for: #function, mode: .update)
         for try await entry in archive {
             do {
                 let checksum = try await archive.extract(entry, consumer: { _ in })
-                XCTAssert(entry.checksum == checksum)
+                let lfh = try await archive.localFileHeader(for: entry)
+                XCTAssert(lfh.checksum == checksum)
             } catch {
                 XCTFail("Failed to unzip data descriptor archive")
             }

--- a/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationReadingTests.swift
@@ -15,7 +15,7 @@ extension ZIPFoundationTests {
 
     func testExtractUncompressedFolderEntries() async throws {
         let archive = await self.archive(for: #function, mode: .read)
-        for try await entry in archive {
+        for entry in try await archive.entries() {
             do {
                 // Test extracting to memory
                 var checksum = try await archive.extract(entry, bufferSize: 32, consumer: { _ in })
@@ -40,7 +40,7 @@ extension ZIPFoundationTests {
 
     func testExtractCompressedFolderEntries() async throws {
         let archive = await self.archive(for: #function, mode: .read)
-        for try await entry in archive {
+        for entry in try await archive.entries() {
             do {
                 // Test extracting to memory
                 var checksum = try await archive.extract(entry, bufferSize: 128, consumer: { _ in })
@@ -65,7 +65,7 @@ extension ZIPFoundationTests {
 
     func testExtractUncompressedDataDescriptorArchive() async throws {
         let archive = await self.archive(for: #function, mode: .read)
-        for try await entry in archive {
+        for entry in try await archive.entries() {
             do {
                 let checksum = try await archive.extract(entry, consumer: { _ in })
                 XCTAssert(entry.checksum == checksum)
@@ -77,7 +77,7 @@ extension ZIPFoundationTests {
 
     func testExtractCompressedDataDescriptorArchive() async throws {
         let archive = await self.archive(for: #function, mode: .update)
-        for try await entry in archive {
+        for entry in try await archive.entries() {
             do {
                 let checksum = try await archive.extract(entry, consumer: { _ in })
                 let lfh = try await archive.localFileHeader(for: entry)
@@ -100,7 +100,7 @@ extension ZIPFoundationTests {
 
     func testExtractMSDOSArchive() async throws {
         let archive = await self.archive(for: #function, mode: .read)
-        for try await entry in archive {
+        for entry in try await archive.entries() {
             do {
                 let checksum = try await archive.extract(entry, consumer: { _ in })
                 XCTAssert(entry.checksum == checksum)
@@ -157,7 +157,7 @@ extension ZIPFoundationTests {
 
     func testCorruptSymbolicLinkErrorConditions() async throws {
         let archive = await self.archive(for: #function, mode: .read)
-        for try await entry in archive {
+        for entry in try await archive.entries() {
             var tempFileURL = URL(fileURLWithPath: NSTemporaryDirectory())
             tempFileURL.appendPathComponent(ProcessInfo.processInfo.globallyUniqueString)
             await XCTAssertSwiftError(try await archive.extract(entry, to: tempFileURL),
@@ -179,7 +179,7 @@ extension ZIPFoundationTests {
     func testExtractEncryptedArchiveErrorConditions() async throws {
         let archive = await self.archive(for: #function, mode: .read)
         var entriesRead = 0
-        for try await _ in archive {
+        for entry in try await archive.entries() {
             entriesRead += 1
         }
         // We currently don't support encryption so we expect failed initialization for entry objects.
@@ -264,7 +264,7 @@ extension ZIPFoundationTests {
             "META-INF/": .directory,
             "META-INF/container.xml": .file
         ]
-        for try await entry in archive {
+        for entry in try await archive.entries() {
             XCTAssertEqual(entry.type, expectedData[entry.path])
         }
     }

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -338,7 +338,12 @@ extension Archive {
         do {
             for try await entry in self {
                 let checksum = try await self.extract(entry, consumer: { _ in })
-                guard checksum == entry.checksum else {
+                // The test files don't always have the CRC in the Central
+                // Directory, which is required by the spec. So we check also
+                // the local file headers.
+                let lfh = try await localFileHeader(for: entry)
+                print(checksum, lfh.checksum, entry.checksum)
+                guard checksum == entry.checksum || checksum == lfh.checksum else {
                     XCTFail("Integrity check failed")
                     return
                 }

--- a/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationTests.swift
@@ -336,13 +336,12 @@ extension ZIPFoundationTests {
 extension Archive {
     func checkIntegrity() async {
         do {
-            for try await entry in self {
+            for entry in try await entries() {
                 let checksum = try await self.extract(entry, consumer: { _ in })
                 // The test files don't always have the CRC in the Central
                 // Directory, which is required by the spec. So we check also
                 // the local file headers.
                 let lfh = try await localFileHeader(for: entry)
-                print(checksum, lfh.checksum, entry.checksum)
                 guard checksum == entry.checksum || checksum == lfh.checksum else {
                     XCTFail("Integrity check failed")
                     return

--- a/Tests/ZIPFoundationTests/ZIPFoundationWritingTests+ZIP64.swift
+++ b/Tests/ZIPFoundationTests/ZIPFoundationWritingTests+ZIP64.swift
@@ -38,7 +38,8 @@ extension ZIPFoundationTests {
         do {
             // Local File Header and Extra Field
             fseeko(archiveFile, 0, SEEK_SET)
-            let lfhSize = checkLocalFileHeaderAndExtraField(entry: entry, dataSize: size,
+            let lfh = try await archive.localFileHeader(for: entry)
+            let lfhSize = checkLocalFileHeaderAndExtraField(header: lfh, dataSize: size,
                                                             entryNameLength: entryName.count) { size in
                 try Data.readChunk(of: size, from: archiveFile)
             }
@@ -69,12 +70,12 @@ extension ZIPFoundationTests {
         }
     }
 
-    private func checkLocalFileHeaderAndExtraField(entry: Entry, dataSize: UInt64, entryNameLength: Int,
+    private func checkLocalFileHeaderAndExtraField(header: Entry.LocalFileHeader, dataSize: UInt64, entryNameLength: Int,
                                                    readData: (Int) throws -> Data) -> UInt64 {
-        XCTAssertEqual(entry.localFileHeader.uncompressedSize, UInt32.max)
-        XCTAssertEqual(entry.localFileHeader.extraFieldData.scanValue(start: 4), dataSize)
-        XCTAssertEqual(entry.localFileHeader.compressedSize, UInt32.max)
-        XCTAssertEqual(entry.localFileHeader.extraFieldData.scanValue(start: 12), dataSize)
+        XCTAssertEqual(header.uncompressedSize, UInt32.max)
+        XCTAssertEqual(header.extraFieldData.scanValue(start: 4), dataSize)
+        XCTAssertEqual(header.compressedSize, UInt32.max)
+        XCTAssertEqual(header.extraFieldData.scanValue(start: 12), dataSize)
         do {
             let lfhExtraFieldOffset = 30 + entryNameLength
             let lfhSize = lfhExtraFieldOffset + 20


### PR DESCRIPTION
Local file headers are not parsed right away anymore, as it can be very costly when streaming a remote ZIP. Instead, we will parse them only on-the-fly when reading the data of a particular entry.