### PR TITLE
Use separate privacy bundle name to avoid conflicts with standalone ZIPFoundation

### DIFF
--- a/ReadiumZIPFoundation.podspec
+++ b/ReadiumZIPFoundation.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '11.0'
 
   s.source_files = 'Sources/ZIPFoundation/*.swift'
-  s.resource_bundles = {'ZIPFoundation_Privacy' => ['Sources/ZIPFoundation/Resources/PrivacyInfo.xcprivacy']}
+  s.resource_bundles = {'ReadiumZIPFoundation_Privacy' => ['Sources/ZIPFoundation/Resources/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
When using both ReadiumZIPFoundation (this fork) and the standalone ZIPFoundation pod in the same project, Xcode fails to build with the following error:

```bash
Multiple commands produce '/path/to/DerivedData/.../ZIPFoundation_Privacy.bundle'
```

# Changes proposed in this PR
* Rename the privacy bundle to `ReadiumZIPFoundation_Privacy`

# Further info for the reviewer

A [workaround](https://github.com/stumpapp/stump/pull/811/commits/99737a167f96a03d3cfdacd96b229f17905cb04b) I had to implement was to manually delete the `ZIPFoundation-ZIPFoundation_Privacy` target in a CocoaPods post_install hook and patch the generated copy scripts to remove references to the deleted bundle. 

If the privacy bundle was just renamed to align with the fork's name, this is not needed
